### PR TITLE
PR, HRM & cfg: Fix Public / Private Contacts labels

### DIFF
--- a/controllers/pr.py
+++ b/controllers/pr.py
@@ -190,7 +190,7 @@ def person():
         s3db.set_method(module, resourcename,
                         method = "private_contacts",
                         action = s3db.pr_Contacts)
-        contacts_tabs.append((settings.get_pr_contacts_tab_label("public_contacts"),
+        contacts_tabs.append((settings.get_pr_contacts_tab_label("private_contacts"),
                               "private_contacts",
                               ))
 

--- a/modules/s3cfg.py
+++ b/modules/s3cfg.py
@@ -4293,8 +4293,8 @@ class S3Config(Storage):
             Labels for contacts tabs
         """
         defaults = {"all": "Contacts",
-                    "private": "Private Contacts",
-                    "public": "Public Contacts",
+                    "private_contacts": "Private Contacts",
+                    "public_contacts": "Public Contacts",
                     }
 
         tabs = self.get_pr_contacts_tabs()


### PR DESCRIPTION
Fixes usage of `settings.pr.contacts_tabs`
1. Modules PR and HRM look up labels by keys `"public_contacts"` and `"private_contacts"` but in `get_pr_contacts_tab_label()` defaults, there are only `"public"` and `"private"` which don't seem to be used anywhere (possibly some confusion with default values in `get_pr_contacts_tabs()`)
2. PR module controler checks if the private tab should be added, but assigns label for public (likely overlooked after copy-paste)