### PR TITLE
AAA: Fix approver mail localization

### DIFF
--- a/modules/s3/s3aaa.py
+++ b/modules/s3/s3aaa.py
@@ -2327,25 +2327,25 @@ $.filterOptionsS3({
             T.force(language)
             if message == "approve_user":
                 subjects[language] = \
-                    T("%(system_name)s - New User Registration Approval Pending") % \
-                            {"system_name": system_name}
-                messages[language] = auth_messages.approve_user % \
+                    s3_str(T("%(system_name)s - New User Registration Approval Pending") % \
+                            {"system_name": system_name})
+                messages[language] = s3_str(auth_messages.approve_user % \
                             dict(system_name = system_name,
                                  first_name = first_name,
                                  last_name = last_name,
                                  email = email,
                                  url = "%(base_url)s/admin/user/%(id)s" % \
                                     dict(base_url=base_url,
-                                         id=user_id))
+                                         id=user_id)))
             elif message == "new_user":
                 subjects[language] = \
-                    T("%(system_name)s - New User Registered") % \
-                            {"system_name": system_name}
+                    s3_str(T("%(system_name)s - New User Registered") % \
+                            {"system_name": system_name})
                 messages[language] = \
-                    auth_messages.new_user % dict(system_name = system_name,
+                    s3_str(auth_messages.new_user % dict(system_name = system_name,
                                                   first_name = first_name,
                                                   last_name = last_name,
-                                                  email = email)
+                                                  email = email))
 
         # Restore language for UI
         T.force(session.s3.language)


### PR DESCRIPTION
Slightly related to the mailing list [topic about AAA localization](https://groups.google.com/forum/#!topic/sahana-eden/EIX2nqkWcEc).

The mails sent to the registered users are translated correctly, but the mails for approvers are not. This is caused by the lazy evaluation of `T()` function, so when the translation language is forced via `T.force()`, it needs to be evaluated before the language changes again, otherwise it always evaluates to the current language.

The additional `s3_str()` call in this PR ensures the evaluation before the language is changed.