### PR TITLE
ORG: Add "Resource Types" to Organisation menu

### DIFF
--- a/modules/s3menus.py
+++ b/modules/s3menus.py
@@ -1551,11 +1551,11 @@ class S3OptionsMenu(object):
                       restrict=[ADMIN])(
                         M("Create", m="create"),
                     ),
-                    M("Resource Types", f="resource_type",
-                      restrict=[ADMIN])(
+                    M(SECTORS, f="sector", restrict=[ADMIN])(
                         M("Create", m="create"),
                     ),
-                    M(SECTORS, f="sector", restrict=[ADMIN])(
+                    M("Resource Types", f="resource_type",
+                      restrict=[ADMIN])(
                         M("Create", m="create"),
                     ),
                 )

--- a/modules/s3menus.py
+++ b/modules/s3menus.py
@@ -1551,6 +1551,10 @@ class S3OptionsMenu(object):
                       restrict=[ADMIN])(
                         M("Create", m="create"),
                     ),
+                    M("Resource Types", f="resource_type",
+                      restrict=[ADMIN])(
+                        M("Create", m="create"),
+                    ),
                     M(SECTORS, f="sector", restrict=[ADMIN])(
                         M("Create", m="create"),
                     ),


### PR DESCRIPTION
Tiny little PR to show *Resource Types* in Organisation menu. Allows browsing, editing, deletion etc.