### PR TITLE
Simile Timeline: Fix encoding for cs and vi labels

### DIFF
--- a/static/scripts/simile/timeline/scripts/l10n/cs/labellers.js
+++ b/static/scripts/simile/timeline/scripts/l10n/cs/labellers.js
@@ -4,11 +4,11 @@
  */
 
 Timeline.GregorianDateLabeller.monthNames["cs"] = [
-    "Leden", "Únor", "Bøezen", "Duben", "Kvìten", "Èerven", "Èervenec", "Srpen", "Záøí", "Øíjen", "Listopad", "Prosinec"
+    "Leden", "Ãšnor", "BÅ™ezen", "Duben", "KvÄ›ten", "ÄŒerven", "ÄŒervenec", "Srpen", "ZÃ¡Å™Ã­", "Å˜Ã­jen", "Listopad", "Prosinec"
 ];
 
 Timeline.GregorianDateLabeller.dayNames["cs"] = [
-    "Ne", "Po", "Út", "St", "Èt", "Pá", "So"
+    "Ne", "Po", "Ãšt", "St", "ÄŒt", "PÃ¡", "So"
 ];
 
 Timeline.GregorianDateLabeller.labelIntervalFunctions["cs"] = function(date, intervalUnit) {

--- a/static/scripts/simile/timeline/scripts/l10n/vi/labellers.js
+++ b/static/scripts/simile/timeline/scripts/l10n/vi/labellers.js
@@ -4,7 +4,7 @@
  */
 
 Timeline.GregorianDateLabeller.monthNames["vi"] = [
-    "Tháng 1", "Tháng 2", "Tháng 3", "Tháng 4", "Tháng 5", "Tháng 6", "Tháng 7", "Tháng 8", "Tháng 9", "Tháng 10", "Tháng 11", "Tháng 12"
+    "ThÃ¡ng 1", "ThÃ¡ng 2", "ThÃ¡ng 3", "ThÃ¡ng 4", "ThÃ¡ng 5", "ThÃ¡ng 6", "ThÃ¡ng 7", "ThÃ¡ng 8", "ThÃ¡ng 9", "ThÃ¡ng 10", "ThÃ¡ng 11", "ThÃ¡ng 12"
 ];
 
 Timeline.GregorianDateLabeller.labelIntervalFunctions["vi"] = function(date, intervalUnit) {


### PR DESCRIPTION
I'm aware that Simile widget is a 3rd party component abandoned since 2015 (at least the version which SE uses is), so it would be for the best to upgrade it completely. For the time being I'm at lest pushing this PR to fix the timeline labels by changing the encoding from ISO-8859-2 to UTF-8.