### PR TITLE
S3CRUD: Allow immutable custom_submits to have interim save button

### DIFF
--- a/modules/s3/s3crud.py
+++ b/modules/s3/s3crud.py
@@ -3126,10 +3126,10 @@ class S3CRUD(S3Method):
         else:
             return
         settings = current.response.s3.crud
+        custom_submit = [item]
         if settings.custom_submit:
-            settings.custom_submit.insert(0, item)
-        else:
-            settings.custom_submit = [item]
+            custom_submit.extend(settings.custom_submit)
+        settings.custom_submit = custom_submit
         return
 
     # -------------------------------------------------------------------------


### PR DESCRIPTION
PR based on issue #1388. Changes *custom_submit* from tuple to list and also makes S3CRUD always convert it to list, which allows `settings.ui.interim_save` to modify the *custom_submit*.

The S3CRUD conversion in commit [101ff4d](https://github.com/trendspotter/eden/commit/101ff4d4c8557c6a8ef9b23ba291d692ce1a6d1b) might not be needed anymore as *custom_submit* is only in CAP module and CRMT template, so feel free to cherry-pick whatever seems the best.
