### PR TITLE
GIS: Fix swapped lat/lon in WKT for get_features_in_radius()

### DIFF
--- a/modules/s3/s3gis.py
+++ b/modules/s3/s3gis.py
@@ -2091,10 +2091,10 @@ class GIS(object):
             # @ToDo: Look at more optimal queries for just those fields we need
             if tablename:
                 # Lookup the resource
-                query_string = cursor.mogrify("SELECT * FROM gis_location, %s WHERE %s.location_id = gis_location.id and ST_DWithin (ST_GeomFromText ('POINT (%s %s)', 4326), the_geom, %s);" % (tablename, tablename, lat, lon, radius))
+                query_string = cursor.mogrify("SELECT * FROM gis_location, %s WHERE %s.location_id = gis_location.id and ST_DWithin (ST_GeomFromText ('POINT (%s %s)', 4326), the_geom, %s);" % (tablename, tablename, lon, lat, radius))
             else:
                 # Lookup the raw Locations
-                query_string = cursor.mogrify("SELECT * FROM gis_location WHERE ST_DWithin (ST_GeomFromText ('POINT (%s %s)', 4326), the_geom, %s);" % (lat, lon, radius))
+                query_string = cursor.mogrify("SELECT * FROM gis_location WHERE ST_DWithin (ST_GeomFromText ('POINT (%s %s)', 4326), the_geom, %s);" % (lon, lat, radius))
 
             cursor.execute(query_string)
             # @ToDo: Export Rows?


### PR DESCRIPTION
Found out why can't I find any features around me as mentioned in [this comment for #1378](https://github.com/sahana/eden/issues/1378#issuecomment-331710389). The latitude and longitude is swapped in `get_features_in_radius()` SQL query.