### PR TITLE
Edu: Add school capacity and contact to XSLT and CSV

### DIFF
--- a/static/formats/s3csv/edu/school.csv
+++ b/static/formats/s3csv/edu/school.csv
@@ -1,1 +1,1 @@
-Name,Type,Organisation,Branch,Phone,Email,Website,Country,L1,L2,L3,L4,L5,Building,Address,Postcode,Lat,Lon,Comments
+Name,Type,Organisation,Branch,Capacity,Contact,Phone,Email,Website,Country,L1,L2,L3,L4,L5,Building,Address,Postcode,Lat,Lon,Comments

--- a/static/formats/s3csv/edu/school.xsl
+++ b/static/formats/s3csv/edu/school.xsl
@@ -238,6 +238,8 @@
             <!-- School data -->
             <data field="code"><xsl:value-of select="col[@field='Code']"/></data>
             <data field="name"><xsl:value-of select="$SchoolName"/></data>
+            <data field="capacity"><xsl:value-of select="col[@field='Capacity']"/></data>
+            <data field="contact"><xsl:value-of select="col[@field='Contact']"/></data>
             <data field="phone"><xsl:value-of select="col[@field='Phone']"/></data>
             <data field="email"><xsl:value-of select="col[@field='Email']"/></data>
             <data field="website"><xsl:value-of select="col[@field='Website']"/></data>


### PR DESCRIPTION
Adds the possibility to define school capacity and contact in imports, since they exist in the *Create* form.

I understand the idea of imports and validation conceptually, but not yet implementation-wise, so I hope I got this one right. (Tests suggest that I did.)