### PR TITLE
DVI: Fix recreq represent

### DIFF
--- a/modules/s3db/dvi.py
+++ b/modules/s3db/dvi.py
@@ -147,11 +147,15 @@ class S3DVIModel(S3Model):
                                  ])
 
         # Reusable fields
+        represent = S3Represent(lookup="dvi_recreq",
+                                fields = ["marker", "date", "bodies_found"],
+                                labels = T("[%(marker)s] %(date)s: %(bodies_found)s bodies"),
+                                )
         dvi_recreq_id = S3ReusableField("dvi_recreq_id", "reference %s" % tablename,
                                         requires = IS_EMPTY_OR(IS_ONE_OF(db,
                                                         "dvi_recreq.id",
-                                                        "[%(marker)s] %(date)s: %(bodies_found)s bodies")),
-                                        represent = lambda id: id,
+                                                        represent)),
+                                        represent = represent,
                                         label=T("Recovery Request"),
                                         ondelete = "RESTRICT")
 
@@ -190,7 +194,7 @@ class S3DVIModel(S3Model):
         morgue_id = S3ReusableField("morgue_id", "reference %s" % tablename,
                                     requires = IS_EMPTY_OR(IS_ONE_OF(db,
                                                     "dvi_morgue.id", "%(name)s")),
-                                    represent = self.morgue_represent,
+                                    represent = S3Represent(lookup="dvi_morgue"),
                                     ondelete = "RESTRICT")
 
         # CRUD Strings
@@ -227,7 +231,7 @@ class S3DVIModel(S3Model):
                      self.pr_pe_label(requires = [IS_NOT_EMPTY(error_message=T("Enter a unique label!")),
                                                   IS_NOT_ONE_OF(db, "dvi_body.pe_label")]),
                      morgue_id(),
-                     dvi_recreq_id(label = T("Recovery Request")),
+                     dvi_recreq_id(),
                      s3_datetime("date_of_recovery",
                                  label = T("Date of Recovery"),
                                  empty=False,
@@ -477,21 +481,5 @@ class S3DVIModel(S3Model):
                            title = c_title,
                            tooltip = c_comment,
                            )
-
-    # -------------------------------------------------------------------------
-    @staticmethod
-    def morgue_represent(id):
-
-        if not id:
-            return current.messages["NONE"]
-
-        db = current.db
-        table = db.dvi_morgue
-        row = db(table.id == id).select(table.name,
-                                        limitby=(0, 1)).first()
-        try:
-            return row.name
-        except:
-            return current.messages.UNKNOWN_OPT
 
 # END =========================================================================


### PR DESCRIPTION
A bug exists where creating a *Recovery request* and subsequently linking the request to a *Dead body* throws following error 500 while visiting `/eden/dvi/body/1/read`

```
Traceback (most recent call last):
  File "/srv/sahana/gluon/restricted.py", line 227, in restricted
    exec ccode in environment
  File "/srv/sahana/applications/eden/controllers/dvi.py", line 289, in <module>
  File "/srv/sahana/gluon/globals.py", line 417, in <lambda>
    self._caller = lambda f: f()
  File "/srv/sahana/applications/eden/controllers/dvi.py", line 153, in body
    return s3_rest_controller(rheader=rheader)
  File "/srv/sahana/applications/eden/models/00_utils.py", line 243, in s3_rest_controller
    output = r(**attr)
  File "applications/eden/modules/s3/s3rest.py", line 691, in __call__
    output = self.resource.crud(self, **attr)
  File "applications/eden/modules/s3/s3rest.py", line 1774, in __call__
    output = self.apply_method(r, **attr)
  File "applications/eden/modules/s3/s3crud.py", line 103, in apply_method
    output = self.read(r, **attr)
  File "applications/eden/modules/s3/s3crud.py", line 649, in read
    format=representation)
  File "applications/eden/modules/s3/s3forms.py", line 516, in __call__
    buttons = buttons)
  File "/srv/sahana/gluon/sqlhtml.py", line 1399, in __init__
    table = self.createform(xfields)
  File "/srv/sahana/gluon/sqlhtml.py", line 1420, in createform
    newrows = formstyle(id, a, b, c)
  File "applications/eden/modules/s3theme.py", line 144, in formstyle_foundation
    return render_row(row_id, label, widget, comment, hidden)
  File "applications/eden/modules/s3theme.py", line 127, in render_row
    submit = widget.element("input", _type="submit")
TypeError: 'NoneType' object is not callable
```

The problem lies in the representation of `recreq`. Before this PR, the request was [represented by its reference ID](https://github.com/sahana/eden/blob/8386145559fa8e4aad4208487d419b2d36c8ded0/modules/s3db/dvi.py#L154). Since the ID is of type `pydal.helpers.classes.Reference` which implements `__getattr__` eventually returning `Null`, the [condition checking if a widget variable has an 'element' attribute](https://github.com/sahana/eden/blob/8386145559fa8e4aad4208487d419b2d36c8ded0/modules/s3theme.py#L126) wrongly passed and subsequent processing resulted in the traceback above.

This PR adds a custom textual representation, [same as shown during *Dead Body* creation](https://github.com/sahana/eden/blob/8386145559fa8e4aad4208487d419b2d36c8ded0/modules/s3db/dvi.py#L153).

Additionally, it removes a duplicit label settings for `dvi_recreq_id()`.