### PR TITLE
Show shelter workflow message only once when interim_save is enabled

### DIFF
--- a/views/cr/shelter_create.html
+++ b/views/cr/shelter_create.html
@@ -4,7 +4,7 @@
 <script type="text/javascript">//<![CDATA[
 $(function(){
  var msg_workflow = '{{=T("The next screen will allow you to detail the number of people here & their needs.")}}<br />'
- $('.form-container :submit').before(msg_workflow)
+ $('.form-container :submit').first().before(msg_workflow)
 })
 //]]></script>
 {{pass}}

--- a/views/cr/shelter_list_filter.html
+++ b/views/cr/shelter_list_filter.html
@@ -4,6 +4,6 @@
 <script type="text/javascript">//<![CDATA[
 $(function(){
  var msg_workflow='{{=T("The next screen will allow you to detail the number of people here & their needs.")}}<br />'
- $('input:submit').before(msg_workflow)
+ $('input:submit').first().before(msg_workflow)
 })
 //]]></script>{{else:}}{{pass}}


### PR DESCRIPTION
Cosmetic issue. When `settings.ui.interim_save = True`, the message *"The next screen will allow you to..."* in shelter creation form is displayed twice (once per submit button). This PR forces the responsible jQuery snippets to take into account only the first submit button.