### PR TITLE
Make Delphi H4 and table headers translatable

### DIFF
--- a/controllers/delphi.py
+++ b/controllers/delphi.py
@@ -699,7 +699,7 @@ def results(r, **attr):
         rows.append(row)
     output = TABLE(THEAD(header), rows,
                    _class="delphi_wide")
-    output = DIV(H4("Array F: # times that solution in column is preferred over it's partner in row"),
+    output = DIV(H4(T("Array F: # times that solution in column is preferred over it's partner in row")),
                  output)
     grids.append(output)
     grids.append(NBSP())
@@ -770,7 +770,7 @@ def results(r, **attr):
         rows.append(row)
     output = TABLE(THEAD(header), rows,
                    _class="delphi_wide")
-    output = DIV(H4("Array P: proportion of times that solution in column is preferred over it's partner in row, assuming that pairs not ranked start at the level of indifference (0.5)"),
+    output = DIV(H4(T("Array P: proportion of times that solution in column is preferred over it's partner in row, assuming that pairs not ranked start at the level of indifference (0.5)")),
                  output)
     grids.append(output)
     grids.append(NBSP())
@@ -816,7 +816,7 @@ def results(r, **attr):
 
     output = TABLE(THEAD(header), rows, footer, footer2,
                    _class="delphi_wide")
-    output = DIV(H4("Array X: unit normal deviate"),
+    output = DIV(H4(T("Array X: unit normal deviate")),
                  output)
     grids.append(output)
     grids.append(NBSP())
@@ -839,7 +839,7 @@ def results(r, **attr):
         rows.append(row)
     output = TABLE(THEAD(header), rows,
                    _class="delphi_wide")
-    output = DIV(H4("Array P2: proportion of times that solution in column is preferred over it's partner in row, assuming that non-votes move towards indifference"),
+    output = DIV(H4(T("Array P2: proportion of times that solution in column is preferred over it's partner in row, assuming that non-votes move towards indifference")),
                  output)
     grids.append(output)
     grids.append(NBSP())
@@ -885,7 +885,7 @@ def results(r, **attr):
 
     output = TABLE(THEAD(header), rows, footer, footer2,
                    _class="delphi_wide")
-    output = DIV(H4("Array U: unit normal deviate of the uncertainty value (assuming that all unvoted items return the probability towards indifference"),
+    output = DIV(H4(T("Array U: unit normal deviate of the uncertainty value (assuming that all unvoted items return the probability towards indifference)")),
                  output)
     grids.append(output)
 

--- a/modules/s3db/delphi.py
+++ b/modules/s3db/delphi.py
@@ -227,7 +227,8 @@ class S3DelphiModel(S3Model):
                            represent = s3_yes_no_represent,
                            ),
                      *s3_meta_fields(),
-                     on_define = lambda table: [table.modified_on.set_attributes(label = T("Last Modification")),
+                     on_define = lambda table: [table.created_by.set_attributes(label = T("Created By")),
+                                                table.modified_on.set_attributes(label = T("Last Modification")),
                                                 ]
                      )
 


### PR DESCRIPTION
Unlike most of the other strings, these particular H4 headings cannot be translated out-of-the-box.

Additionally, the *Problems* table contains a *Created By* column, which was missing a label override allowing for translation.