### PR TITLE
Edu, Inv: Fix display of obsolete flag when NONE is not a single character

### DIFF
--- a/modules/s3db/edu.py
+++ b/modules/s3db/edu.py
@@ -198,7 +198,7 @@ class S3SchoolModel(S3Model):
                            default = False,
                            label = T("Obsolete"),
                            represent = lambda opt: \
-                                       (opt and [T("Obsolete")] or NONE)[0],
+                                       (opt and [T("Obsolete")] or [NONE])[0],
                            readable = False,
                            writable = False,
                            ),

--- a/modules/s3db/inv.py
+++ b/modules/s3db/inv.py
@@ -266,7 +266,7 @@ class S3WarehouseModel(S3Model):
                            default = False,
                            label = T("Obsolete"),
                            represent = lambda opt: \
-                                       (opt and [T("Obsolete")] or NONE)[0],
+                                       (opt and [T("Obsolete")] or [NONE])[0],
                            readable = False,
                            writable = False,
                            ),


### PR DESCRIPTION
When `NONE` is an empty string, these two places throw error 500 when the page is rendered. When `NONE` is longer than a single character, these two would display just `NONE[0]`, ie. the first character of the string.

Checked also the other occurrences of `(opt and ...` and in the rest the `NONE` is already wrapped to list.