### PR TITLE
Unrestrict patient's home location

### DIFF
--- a/modules/s3db/patient.py
+++ b/modules/s3db/patient.py
@@ -203,9 +203,9 @@ class S3PatientModel(S3Model):
                                     ),
                           #person_id(label = T("Home Relative")),
                           self.gis_location_id(
-                              label = T("Home City"),
-                              requires = IS_LOCATION(level="L2"),
-                              widget = S3LocationAutocompleteWidget(level="L2"),
+                              label = T("Home Location"),
+                              requires = IS_LOCATION(),
+                              widget = S3LocationAutocompleteWidget(),
                               ),
                           Field("phone",
                                 label = T("Home Phone Number"),


### PR DESCRIPTION
Patient module allows to enter *Home City*, however the requirement specifies that L2 location needs to be entered, which corresponds to *County / District* level. Moreover, this is the only place (except from GIS module itself) where the requirements for specific level are imposed directly in *IS_LOCATION()*. Additionally, the *S3LocationAutocompleteWidget* doesn't seem to support the level restriction as it autocompletes all levels and not just L2.