### PR TITLE
Fix creation of registration_organisation_default

### DIFF
--- a/modules/s3cfg.py
+++ b/modules/s3cfg.py
@@ -685,7 +685,7 @@ class S3Config(Storage):
                 if row:
                     organisation_id = row.id
                 else:
-                    organisation_id = table.insert(name = name)
+                    organisation_id = table.insert(name = organisation_id)
         return organisation_id
 
     def get_auth_registration_requests_organisation_group(self):


### PR DESCRIPTION
This PR amends da7b7d0.

When `settings.auth.registration_organisation_default` is set to a string and the organization doesn't exist yet, login/sign-in page fails with error 500 due to undefined variable.

```
Traceback (most recent call last):
  File "/srv/web2py/gluon/restricted.py", line 219, in restricted
    exec(ccode, environment)
  File "/srv/web2py/applications/eden/controllers/default.py", line 1558, in <module>
  File "/srv/web2py/gluon/globals.py", line 419, in <lambda>
    self._caller = lambda f: f()
  File "/srv/web2py/applications/eden/controllers/default.py", line 547, in user
    auth.configure_user_fields()
  File "applications/eden/modules/s3/s3aaa.py", line 1814, in configure_user_fields
    organisation_id.default = deployment_settings.get_auth_registration_organisation_default()
  File "applications/eden/modules/s3cfg.py", line 688, in get_auth_registration_organisation_default
    organisation_id = table.insert(name = name)
NameError: global name 'name' is not defined
```