### PR TITLE
Add missing T() for Delphi results view

### DIFF
--- a/views/delphi/results.html
+++ b/views/delphi/results.html
@@ -3,7 +3,7 @@
  {{=rheader}}
 </div>
 <div id='component'>
-<p>Users who have voted so far: <b>{{=num_voted}}</b></p>
+<p>{{=T("Users who have voted so far")}}: <b>{{=num_voted}}</b></p>
 {{=chart}}
 {{=summary}}
 <p>&nbsp;</p>


### PR DESCRIPTION
This PR makes translation possible for one string in Delphi module I've missed in PR #1464