### PR TITLE
Prepopulate the gis_hiearchy with default values if none are provided

### DIFF
--- a/models/zzz_1st_run.py
+++ b/models/zzz_1st_run.py
@@ -314,6 +314,17 @@ if len(pop_list) > 0:
                 s3_str = s3base.s3_str
                 info("\n".join(s3_str(el) for el in error))
 
+    # Check to see if the "SITE_DEFAULT" gis_hierarchy was prepopulated.
+    # Use our default gis_hierarchy if not.
+    table = s3db.gis_hierarchy
+    query = (table.uuid == "SITE_DEFAULT")
+    row = db(query).select(table.id, limitby=(0, 1)).first()
+    if not row:
+        info("\nWarning: No gis_hierarchy provided, using default.")
+        csv = path_join(request_folder, "modules", "templates", "default", "base", "gis_hierarchy.csv")
+        xsl = path_join(request_folder, "static", "formats", "s3csv", "gis", "hierarchy.xsl")
+        bi.execute_import_task([1, "gis", "hierarchy", csv, xsl, None])
+
     info("\nUpdating database...")
 
     # Restore setting for strict email-matching


### PR DESCRIPTION
The gis_hierarchy is required for the app to be functional. This
modifies the first run script to check that a gis_hiearchy has been
populated. If not, then the default gis_hierarchy is loaded.

Fixes #1502