### PR TITLE
Display error in map component if there is no GIS config

### DIFF
--- a/languages/bs.py
+++ b/languages/bs.py
@@ -4624,7 +4624,6 @@
 'Manual synchronization started in the background.': 'Ručna sinhronizacija započeta u pozadini.',
 'Many': 'Mnogo',
 'Map': 'Karta',
-'Map cannot display without prepop data!': 'Mapa se ne može prikazati bez pripremljenih podataka',
 'Map Center Latitude': 'Geografska širina središta mape',
 'Map Center Longitude': 'Geografska dužina centra mape',
 'Map Profile': 'Konfiguracija karte',

--- a/languages/fa.py
+++ b/languages/fa.py
@@ -1648,7 +1648,6 @@
 'Mandatory. The base URL to access the service. e.g. http://host.domain/geoserver/wfs?': 'اجباری. URL اساسی برای دسترسی یافتن به خدمات. مثلاً http://host.domain/geoserver/wfs?',
 'Mandatory. The base URL to access the service. e.g. http://host.domain/geoserver/wms?': 'اجباری. URL اساسی برای دسترسی یافتن به خدمات. مثلاً http://host.domain/geoserver/wms?',
 'Map': 'نقشه',
-'Map cannot display without prepop data!': 'نقشه بدون معلومات prepop نمایش داده نمی تواند',
 'Map Center Latitude': 'عرض جغرافیایی مرکز نقشه',
 'Map Center Longitude': 'طول جغرافیایی مرکز نقشه',
 'Map Profile': 'تنظیمات نقشه',

--- a/languages/it.py
+++ b/languages/it.py
@@ -3224,7 +3224,6 @@
 'Manual Synchronization': 'Sincronizzazione manuale',
 'Many': 'Molti',
 'Map': 'Mappa',
-'Map cannot display without prepop data!': 'La mappa non può essere visualizzata senza dati prepop!',
 'Map Center Latitude': 'Latitudine del centro della mappa',
 'Map Center Longitude': 'Longitudine del centro della mappa',
 'Map Configuration': 'Configurazione della mappa  ',

--- a/languages/km.py
+++ b/languages/km.py
@@ -1581,7 +1581,6 @@
 'Map Settings': 'ការ​កំណត់ផែនទី',
 'Map Viewing Client': 'កម្មវិធី​មើល​ផែនទី',
 'Map Zoom': 'ពង្រីកផែនទី',
-'Map cannot display without prepop data!': 'ផែនទី​មិន​អាចបង្ហាញ​ដោយ​គ្មានទិន្នន័យ prepop បានឡើយ!',
 'Map has been copied and set as Default': 'ផែនទី​ត្រូវ​បាន​ចម្លង និង​កំណត់​ជា​លំនាំដើម',
 'Map has been set as Default': 'ផែនទី​ត្រូវ​បាន​កំណត់​ជា​លំនាំដើម',
 'Map is already your Default': 'ផែនទី​របស់អ្នក​ត្រឡប់ទៅ​លំនាំដើម​រួចហើយ',

--- a/languages/my.py
+++ b/languages/my.py
@@ -1444,7 +1444,6 @@
 'Map Styles': '‌ေျမပံု ပံုစံမ်ား',
 'Map Viewing Client': 'လက္ေအာက္ခံမ်ားကိုၾကည့္သည့္ေျမပံု',
 'Map Zoom': '‌ေျမပံုကို အနီးကပ္ဆြဲယူၾကည္‌့ရႈျခင္း',
-'Map cannot display without prepop data!': 'prepop အခ်က္အလက္မပါဘဲ ေျမပံုဖြင့္ မရပါ',
 'Map has been copied and set as Default': '‌ေျမပံုကို ပံုေသအေနအထားျဖင့္ေကာ္ပီကူးယူသည္',
 'Map has been set as Default': '‌ေျမပံုကို ပံုေသအေနအထားထားသည္',
 'Map is already your Default': 'ေျမပံုကို ပံုေသအေျခအေနသုိ႔ထားၿပီးျဖစ္သည္',

--- a/languages/ne.py
+++ b/languages/ne.py
@@ -1727,7 +1727,6 @@
 'Mandatory. The base URL to access the service. e.g. http://host.domain/geoserver/wfs?': 'आवश्यक.  सेवामा पहुँचको निम्ति आधारभुत यू.आर.एल. जस्तै, http://host.domain/geoserver/wfs?',
 'Mandatory. The base URL to access the service. e.g. http://host.domain/geoserver/wms?': 'आवश्यक.  सेवामा पहुँचको निम्ति आधारभुत यू.आर.एल. जस्तै, http://host.domain/geoserver/wms?',
 'Map': 'नक्सा',
-'Map cannot display without prepop data!': 'आँकडाबिना नक्सा देखाउन सकिँदैन !',
 'Map Center Latitude': 'नक्सा केन्द्रिय अक्षांश',
 'Map Center Longitude': 'नक्सा केन्द्रिय देशान्तर',
 'Map Profile': 'नक्सा बनावट',

--- a/languages/prs.py
+++ b/languages/prs.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-{ 
+{
 "A location that specifies the geographic area for this region. This can be a location from the location hierarchy, or a 'group location', or a location that has a boundary for the area.": "یک موقعیت که منطقه جغرافیایی را برای این ساحه مشخص می کند. این یک موقعیت از سلسله موقعیت ها یا 'موقعیت گروپ' یا موقعیت است که دارای سرحد با منطقه می باشد.",
 "A volunteer is defined as active if they've participated in an average of 8 or more hours of Program work or Trainings per month in the last year": 'یک رضاکار فعال گفته می شود اگر حد اوسط در برنامه های کاری یا تربیوی 8 ساعته یا بیشتر از 8 ساعته در یک ماه در سال گذشته اشتراک کرده باشد.',
 "Acronym of the organization's name, eg. IFRC.": 'سر نام اسم موسسه برای مثال: IFRC',
@@ -1682,7 +1682,6 @@
 'Map Settings': 'ترتیبات نقشه',
 'Map Viewing Client': 'مشتری دیدن نقشه',
 'Map Zoom': 'زوم نقشه',
-'Map cannot display without prepop data!': 'نقشه بدون معلومات prepop نمایش داده نمی تواند',
 'Map has been copied and set as Default': 'نقشه کاپی شد و منحیث پیش فرض تنظیم گردید',
 'Map has been set as Default': 'نقشه منحیث پیش فرض تنظیم گردید',
 'Map is already your Default': 'نقشه قبلاً منحیث پیش فرض تعیین شده است',

--- a/languages/ps.py
+++ b/languages/ps.py
@@ -1677,7 +1677,6 @@
 'Map Settings': 'د نقشه تنظیمات',
 'Map Viewing Client': 'د نقشه د ښکاریدو مشتری',
 'Map Zoom': 'د نقشه نزدیوالی',
-'Map cannot display without prepop data!': 'نقشه نه شوی کولای بی له ( prepop ) معلوماتو څخه ښکاره کړی',
 'Map has been copied and set as Default': 'کاپی نقشه شوی او په قراردادی توګه تعین شوی',
 'Map has been set as Default': 'نقشه په قراردادی توګه تعین شوی',
 'Map is already your Default': 'نقشه مخکی د مخکی ستاسو قراردادی دی',

--- a/modules/s3/s3gis.py
+++ b/modules/s3/s3gis.py
@@ -6440,6 +6440,7 @@ class MAP(DIV):
             # No prepop - Bail
             if auth.s3_has_permission("create", "gis_hierarchy"):
                 error_message = DIV(_class="mapError")
+                # Deliberately not T() to save unneccessary load on translators
                 error_message.append("Map cannot display without GIS config!")
                 error_message.append(XML(" (You can can create one "))
                 error_message.append(A("here", _href=URL(c="gis", f="config")))
@@ -6447,7 +6448,7 @@ class MAP(DIV):
                 self.error_message = error_message
             else:
                 self.error_message = DIV(
-                    "Map cannot display without GIS config!",
+                    "Map cannot display without GIS config!",  # Deliberately not T() to save unneccessary load on translators
                     _class="mapError"
                     )
             return None
@@ -7597,9 +7598,22 @@ class MAP2(DIV):
 
         if options is None:
             # No Map Config: Just show error in the DIV
-            self.components = [DIV("Map cannot display without prepop data!", # Deliberately not T() to save unneccessary load on translators
-                                   _class="error"),
-                               ]
+            auth = current.auth
+
+            if auth.s3_has_permission("create", "gis_hierarchy"):
+                error_message = DIV(_class="mapError")
+                # Deliberately not T() to save unneccessary load on translators
+                error_message.append("Map cannot display without GIS config!")
+                error_message.append(XML(" (You can can create one "))
+                error_message.append(A("here", _href=URL(c="gis", f="config")))
+                error_message.append(")")
+            else:
+                error_message = DIV(
+                    "Map cannot display without GIS config!",  # Deliberately not T() to save unneccessary load on translators
+                    _class="mapError"
+                    )
+
+            self.components = [error_message]
             return super(MAP2, self).xml()
 
         map_id = self.opts.get("id", "default_map")

--- a/modules/s3/s3gis.py
+++ b/modules/s3/s3gis.py
@@ -6432,7 +6432,6 @@ class MAP(DIV):
         # Fresh _setup() call, reset error message
         self.error_message = None
 
-        T = current.T
         auth = current.auth
 
         # Read configuration
@@ -6440,19 +6439,15 @@ class MAP(DIV):
         if not config:
             # No prepop - Bail
             if auth.s3_has_permission("create", "gis_hierarchy"):
-                error_message = DIV()
-                error_message.append(SPAN(
-                    T("Map cannot display without GIS config!"),
-                    _class="mapError"
-                    ))
-                error_message.append(XML(T(
-                    " (You can can create one <a href='%(url)s'>here</a>)" %
-                    {"url": URL(c="gis", f="config")}
-                    )))
+                error_message = DIV(_class="mapError")
+                error_message.append("Map cannot display without GIS config!")
+                error_message.append(XML(" (You can can create one "))
+                error_message.append(A("here", _href=URL(c="gis", f="config")))
+                error_message.append(")")
                 self.error_message = error_message
             else:
                 self.error_message = DIV(
-                    T("Map cannot display without GIS config!"),
+                    "Map cannot display without GIS config!",
                     _class="mapError"
                     )
             return None

--- a/modules/s3/s3gis.py
+++ b/modules/s3/s3gis.py
@@ -6387,6 +6387,8 @@ class MAP(DIV):
         # We haven't yet run _setup()
         self.setup = False
         self.callback = None
+        self.error_message = None
+        self.components = []
 
         # Options for server-side processing
         self.opts = opts
@@ -6395,16 +6397,6 @@ class MAP(DIV):
 
         # Options for client-side processing
         self.options = {}
-
-        # Components
-        # Map (Embedded not Window)
-        components = [DIV(DIV(_class="map_loader"),
-                              _id="%s_panel" % map_id)
-                      ]
-
-        self.components = components
-        for c in components:
-            self._setnode(c)
 
         # Adapt CSS to size of Map
         _class = "map_wrapper"
@@ -6437,16 +6429,36 @@ class MAP(DIV):
               into scripts (callback or otherwise)
         """
 
+        # Fresh _setup() call, reset error message
+        self.error_message = None
+
+        T = current.T
+        auth = current.auth
+
         # Read configuration
         config = GIS.get_config()
         if not config:
             # No prepop - Bail
-            current.session.error = current.T("Map cannot display without prepop data!")
-            redirect(URL(c="default", f="index"))
+            if auth.s3_has_permission("create", "gis_hierarchy"):
+                error_message = DIV()
+                error_message.append(SPAN(
+                    T("Map cannot display without GIS config!"),
+                    _class="mapError"
+                    ))
+                error_message.append(XML(T(
+                    " (You can can create one <a href='%(url)s'>here</a>)" %
+                    {"url": URL(c="gis", f="config")}
+                    )))
+                self.error_message = error_message
+            else:
+                self.error_message = DIV(
+                    T("Map cannot display without GIS config!"),
+                    _class="mapError"
+                    )
+            return None
 
         T = current.T
         db = current.db
-        auth = current.auth
         s3db = current.s3db
         request = current.request
         response = current.response
@@ -6480,6 +6492,12 @@ class MAP(DIV):
                 "gis_too_many_features": T("There are too many features, please Zoom In or Filter"),
                 "gis_zoomin": T("Zoom In"),
                 }
+
+        ##########
+        # Loader
+        ##########
+
+        self.append(DIV(DIV(_class="map_loader"), _id="%s_panel" % self.id))
 
         ##########
         # Viewport
@@ -7125,6 +7143,9 @@ class MAP(DIV):
         if not self.setup:
             result = self._setup()
             if result is None:
+                if self.error_message:
+                    self.append(self.error_message)
+                    return super(MAP, self).xml()
                 return ""
 
         # Add ExtJS

--- a/modules/unit_tests/s3/s3gis.py
+++ b/modules/unit_tests/s3/s3gis.py
@@ -778,8 +778,9 @@ class S3NoGisConfigTests(unittest.TestCase):
     # -------------------------------------------------------------------------
     @classmethod
     def setUpClass(cls):
-        table = current.s3db.gis_config
-        table.truncate()
+        current.s3db.event_config.truncate()
+        current.s3db.gis_menu.truncate()
+        current.s3db.gis_config.truncate()
         current.response.s3.gis.config = None
 
     # -------------------------------------------------------------------------

--- a/modules/unit_tests/s3/s3gis.py
+++ b/modules/unit_tests/s3/s3gis.py
@@ -778,8 +778,7 @@ class S3NoGisConfigTests(unittest.TestCase):
     # -------------------------------------------------------------------------
     @classmethod
     def setUpClass(cls):
-        from s3.s3gis import GIS
-        cls.original_get_config = GIS.get_config
+        cls.original_get_config = staticmethod(GIS.get_config)
         GIS.get_config = staticmethod(lambda: None)
 
     # -------------------------------------------------------------------------
@@ -797,7 +796,7 @@ class S3NoGisConfigTests(unittest.TestCase):
     # -------------------------------------------------------------------------
     @classmethod
     def tearDownClass(cls):
-        GIS.get_config = cls.original_get_config
+        GIS.get_config = staticmethod(cls.original_get_config)
 
 # =============================================================================
 if __name__ == "__main__":

--- a/modules/unit_tests/s3/s3gis.py
+++ b/modules/unit_tests/s3/s3gis.py
@@ -791,7 +791,7 @@ class S3NoGisConfigTests(unittest.TestCase):
     def testMap2Xml(self):
         map = MAP2()
         xml = map.xml()
-        self.assertTrue("Map cannot display without GIS config!" in xml)
+        self.assertTrue(b"Map cannot display without GIS config!" in xml)
 
     # -------------------------------------------------------------------------
     @classmethod

--- a/modules/unit_tests/s3/s3gis.py
+++ b/modules/unit_tests/s3/s3gis.py
@@ -778,8 +778,9 @@ class S3NoGisConfigTests(unittest.TestCase):
     # -------------------------------------------------------------------------
     @classmethod
     def setUpClass(cls):
-        cls.original_get_config = current.gis.get_config
-        current.gis.get_config = lambda: None
+        from s3.s3gis import GIS
+        cls.original_get_config = GIS.get_config
+        GIS.get_config = staticmethod(lambda: None)
 
     # -------------------------------------------------------------------------
     def testMapSetup(self):
@@ -796,7 +797,7 @@ class S3NoGisConfigTests(unittest.TestCase):
     # -------------------------------------------------------------------------
     @classmethod
     def tearDownClass(cls):
-        current.gis.get_config = cls.original_get_config
+        GIS.get_config = cls.original_get_config
 
 # =============================================================================
 if __name__ == "__main__":

--- a/modules/unit_tests/s3/s3gis.py
+++ b/modules/unit_tests/s3/s3gis.py
@@ -774,10 +774,36 @@ class S3LocationTreeTests(unittest.TestCase):
         current.db.rollback()
 
 # =============================================================================
+class S3NoGisConfigTests(unittest.TestCase):
+    # -------------------------------------------------------------------------
+    @classmethod
+    def setUpClass(cls):
+        table = current.s3db.gis_config
+        table.truncate()
+        current.response.s3.gis.config = None
+
+    # -------------------------------------------------------------------------
+    def testMapSetup(self):
+        map = MAP()
+        setup_result = map._setup()
+        self.assertIsNone(setup_result)
+        self.assertIsNotNone(map.error_message)
+
+    # -------------------------------------------------------------------------
+    @classmethod
+    def tearDownClass(cls):
+        current.auth.override = False
+        current.db.rollback()
+
+        # Re-cache the config
+        current.gis.get_config()
+
+# =============================================================================
 if __name__ == "__main__":
 
     run_suite(
         S3LocationTreeTests,
+        S3NoGisConfigTests,
     )
 
 # END ========================================================================

--- a/modules/unit_tests/s3/s3gis.py
+++ b/modules/unit_tests/s3/s3gis.py
@@ -788,6 +788,11 @@ class S3NoGisConfigTests(unittest.TestCase):
         self.assertIsNone(setup_result)
         self.assertIsNotNone(map.error_message)
 
+    def testMap2Xml(self):
+        map = MAP2()
+        xml = map.xml()
+        self.assertTrue("Map cannot display without GIS config!" in xml)
+
     # -------------------------------------------------------------------------
     @classmethod
     def tearDownClass(cls):

--- a/modules/unit_tests/s3/s3gis.py
+++ b/modules/unit_tests/s3/s3gis.py
@@ -778,10 +778,8 @@ class S3NoGisConfigTests(unittest.TestCase):
     # -------------------------------------------------------------------------
     @classmethod
     def setUpClass(cls):
-        current.s3db.event_config.truncate()
-        current.s3db.gis_menu.truncate()
-        current.s3db.gis_config.truncate()
-        current.response.s3.gis.config = None
+        cls.original_get_config = current.gis.get_config
+        current.gis.get_config = lambda: None
 
     # -------------------------------------------------------------------------
     def testMapSetup(self):
@@ -793,11 +791,7 @@ class S3NoGisConfigTests(unittest.TestCase):
     # -------------------------------------------------------------------------
     @classmethod
     def tearDownClass(cls):
-        current.auth.override = False
-        current.db.rollback()
-
-        # Re-cache the config
-        current.gis.get_config()
+        current.gis.get_config = cls.original_get_config
 
 # =============================================================================
 if __name__ == "__main__":

--- a/static/themes/default/widgets.css
+++ b/static/themes/default/widgets.css
@@ -571,6 +571,10 @@ ul.ui-autocomplete {
     font-weight: bold;
 }
 
+.mapError {
+  border: solid 1px red;
+}
+
 /* Help Popup */
 .tooltip,
 .tooltipbody,


### PR DESCRIPTION
Displaying the error in the map component allows the rest of the webpage
to load normally and removes an unsafe redirect from a lower level
function, as suggested in #1513.

This commit also moves the instantiation of the loader component into
the `_setup()` method after we've fetched the config, to ensure that the
error message doesn't appear with a permanent loading icon above it.