### PR TITLE
Refactor `auth_user_temp` into an S3Model class

### DIFF
--- a/modules/s3/s3aaa.py
+++ b/modules/s3/s3aaa.py
@@ -333,30 +333,6 @@ Thank you"""
                          *utable_fields)
             utable = settings.table_user = db[uname]
 
-        # Fields configured in configure_user_fields
-
-        # Temporary User Table
-        # for storing User Data that will be used to create records for
-        # the user once they are approved
-        #
-        # @ToDo: Move to modules/s3db/auth.py, so that it doesn't need to be loaded every request
-        #
-        define_table("auth_user_temp",
-                     Field("user_id", utable),
-                     Field("home"),
-                     Field("mobile"),
-                     Field("image", "upload",
-                           length = current.MAX_FILENAME_LENGTH,
-                           ),
-                     Field("consent"),
-                     Field("custom", "json",
-                           requires = IS_EMPTY_OR(IS_JSONS3()),
-                           ),
-                     S3MetaFields.uuid(),
-                     S3MetaFields.created_on(),
-                     S3MetaFields.modified_on(),
-                     )
-
         # Group table (roles)
         gtable = settings.table_group
         gname = settings.table_group_name
@@ -2329,8 +2305,7 @@ $.filterOptionsS3({
             @ToDo: If these fields are implemented with the InlineForms functionality,
             this function may become redundant
         """
-
-        temptable = current.db.auth_user_temp
+        temptable = current.s3db.auth_user_temp
 
         form_vars = form.vars
         user_id = form_vars.id
@@ -2726,7 +2701,7 @@ $.filterOptionsS3({
 
         utable = self.settings.table_user
 
-        ttable = db.auth_user_temp
+        ttable = s3db.auth_user_temp
         ptable = s3db.pr_person
         ctable = s3db.pr_contact
         ltable = s3db.pr_person_user

--- a/modules/s3db/auth.py
+++ b/modules/s3db/auth.py
@@ -32,7 +32,8 @@ __all__ = ("AuthDomainApproverModel",
            "AuthConsentModel",
            "AuthMasterKeyModel",
            "auth_Consent",
-           "auth_user_options_get_osm"
+           "auth_user_options_get_osm",
+           "AuthUserTempModel",
            )
 
 import datetime
@@ -1137,5 +1138,38 @@ def auth_user_options_get_osm(pe_id):
         return record.osm_oauth_consumer_key, record.osm_oauth_consumer_secret
     else:
         return None
+
+# =============================================================================
+class AuthUserTempModel(S3Model):
+
+    names = ("auth_user_temp",)
+
+    def model(self):
+        # Temporary User Table
+        # for storing User Data that will be used to create records for
+        # the user once they are approved
+        #
+        utable = current.auth.settings.table_user
+
+        self.define_table("auth_user_temp",
+                     Field("user_id", utable),
+                     Field("home"),
+                     Field("mobile"),
+                     Field("image", "upload",
+                           length = current.MAX_FILENAME_LENGTH,
+                           ),
+                     Field("consent"),
+                     Field("custom", "json",
+                           requires = IS_EMPTY_OR(IS_JSONS3()),
+                           ),
+                     S3MetaFields.uuid(),
+                     S3MetaFields.created_on(),
+                     S3MetaFields.modified_on(),
+                     )
+
+        # ---------------------------------------------------------------------
+        # Pass names back to global scope (s3.*)
+        #
+        return {}
 
 # END =========================================================================

--- a/modules/templates/CCC/controllers.py
+++ b/modules/templates/CCC/controllers.py
@@ -1081,11 +1081,11 @@ class register(S3CustomController):
             user_id = utable.insert(**utable._filter_fields(form_vars, id=False))
             form_vars.id = user_id
 
-            # Save temporary user fields in db.auth_user_temp
+            # Save temporary user fields in s3db.auth_user_temp
             # Default just handles mobile, home, consent
             #auth.s3_user_register_onaccept(form)
 
-            temptable = db.auth_user_temp
+            temptable = s3db.auth_user_temp
             record  = {"user_id": user_id}
 
             # Store the mobile_phone ready to go to pr_contact
@@ -1265,6 +1265,7 @@ class verify_email(S3CustomController):
     def __call__(self):
 
         db = current.db
+        s3db = current.s3db
         auth = current.auth
         auth_settings = auth.settings
 
@@ -1283,7 +1284,7 @@ class verify_email(S3CustomController):
         user_id = user.id
 
         # Read custom fields to determine registration type
-        temptable = db.auth_user_temp
+        temptable = s3db.auth_user_temp
         record = db(temptable.user_id == user_id).select(temptable.custom,
                                                          limitby = (0, 1),
                                                          ).first()
@@ -1299,10 +1300,10 @@ class verify_email(S3CustomController):
         if not agency and not organisation_id:
             # Donor/Individual/Group, so doesn't need approval
             # Add hook to process custom fields
-            current.s3db.configure("auth_user",
-                                   register_onaccept = auth_user_register_onaccept,
-                                   )
-            # Calls s3_link_user() which calls s3_link_to_person() which applies 'normal' data from db.auth_user_temp (home_phone, mobile_phone, consent)
+            s3db.configure("auth_user",
+                           register_onaccept = auth_user_register_onaccept,
+                           )
+            # Calls s3_link_user() which calls s3_link_to_person() which applies 'normal' data from s3db.auth_user_temp (home_phone, mobile_phone, consent)
             # Calls s3_auth_user_register_onaccept() which calls our custom auth_user_register_onaccept
             auth.s3_approve_user(user)
 
@@ -1449,9 +1450,10 @@ def auth_user_register_onaccept(user_id):
     """
 
     db = current.db
+    s3db = current.s3db
 
     # Read custom fields & determine registration type
-    temptable = db.auth_user_temp
+    temptable = s3db.auth_user_temp
     record = db(temptable.user_id == user_id).select(temptable.custom,
                                                      limitby = (0, 1),
                                                      ).first()
@@ -1460,7 +1462,6 @@ def auth_user_register_onaccept(user_id):
         return
 
     auth = current.auth
-    s3db = current.s3db
     get_config = s3db.get_config
 
     custom = json.loads(record.custom)

--- a/modules/unit_tests/s3/s3aaa.py
+++ b/modules/unit_tests/s3/s3aaa.py
@@ -4543,7 +4543,9 @@ class S3UserRegisterOnAcceptTests(unittest.TestCase):
         mobile = "(333) 333-3333"
         consent = "yes"
 
-        table = s3db.auth_user_temp
+        db = current.db
+
+        table = current.s3db.auth_user_temp
         query = (table.user_id == user_id)
         row = db(query).select(table.id, limitby=(0, 1)).first()
         self.assertIsNone(row)

--- a/modules/unit_tests/s3/s3aaa.py
+++ b/modules/unit_tests/s3/s3aaa.py
@@ -4533,6 +4533,41 @@ class EntityRoleManagerTests(unittest.TestCase):
         pass
 
 # =============================================================================
+class S3UserRegisterOnAcceptTests(unittest.TestCase):
+    """ Test AuthS3.s3_auth_user_register_onaccept """
+
+    # -------------------------------------------------------------------------
+    def testInsert(self):
+        user_id = 1
+        home = "(555) 555-5555"
+        mobile = "(333) 333-3333"
+        consent = "yes"
+
+        table = s3db.auth_user_temp
+        query = (table.user_id == user_id)
+        row = db(query).select(table.id, limitby=(0, 1)).first()
+        self.assertIsNone(row)
+
+        form = Storage(
+            vars=Storage(
+                id=user_id,
+                home=home,
+                mobile=mobile,
+                consent=consent,
+        ))
+        current.auth.s3_user_register_onaccept(form)
+
+        row = db(query).select(limitby=(0, 1)).first()
+        self.assertIsNotNone(row)
+        self.assertEqual(row.home, home)
+        self.assertEqual(row.mobile, mobile)
+        self.assertEqual(row.consent, consent)
+
+    # -------------------------------------------------------------------------
+    def tearDown(self):
+        current.db.rollback()
+
+# =============================================================================
 if __name__ == "__main__":
 
     run_suite(
@@ -4548,6 +4583,7 @@ if __name__ == "__main__":
         RealmEntityTests,
         LinkToPersonTests,
         EntityRoleManagerTests,
+        S3UserRegisterOnAcceptTests,
     )
 
 # END ========================================================================


### PR DESCRIPTION
Addresses #1517

Moves the `auth_user_temp` table from db to s3db to prevent it from
unnecessarily being loaded on every request.

Includes a basic unit test, but I also manually tested registering a
user, approving the user, disabling the user, and re-approving the user
with the CCC template.