### PR TITLE
Use == and != when comparing literals to fix python3.8 SyntaxWarning

### DIFF
--- a/modules/nameparser/parser.py
+++ b/modules/nameparser/parser.py
@@ -691,7 +691,7 @@ class HumanName(object):
                 # http://code.google.com/p/python-nameparser/issues/detail?id=11
                 continue
 
-            if i is 0:
+            if i == 0:
                 new_piece = " ".join(pieces[i:i+2])
                 if self.is_title(pieces[i+1]):
                     # when joining to a title, make new_piece a title too

--- a/modules/s3/s3gis.py
+++ b/modules/s3/s3gis.py
@@ -1347,7 +1347,7 @@ class GIS(object):
                 # The requested config must be invalid, so just use site default
                 row = rows.first()
 
-        elif config_id is 0:
+        elif config_id == 0:
             # Use site default
             query = (ctable.uuid == "SITE_DEFAULT")
             # May well not be complete, so Left Join

--- a/modules/s3/s3import.py
+++ b/modules/s3/s3import.py
@@ -1200,9 +1200,9 @@ $('#import-items').on('click','.toggle-item',function(){$('.importItem.item-'+$(
         if timestmp != None:
             current.session.flash = messages.job_completed % \
                                         (self.date_represent(timestmp), msg)
-        elif totals[1] is not 0:
+        elif totals[1] != 0:
             current.session.error = msg
-        elif totals[2] is not 0:
+        elif totals[2] != 0:
             current.session.warning = msg
         else:
             current.session.flash = msg

--- a/modules/s3/s3resource.py
+++ b/modules/s3/s3resource.py
@@ -3925,7 +3925,7 @@ class S3Resource(object):
                 seen(selector)
                 append(f)
 
-        if id_column is 0:
+        if id_column == 0:
             fields.insert(0, id_field)
 
         return fields


### PR DESCRIPTION
Comparing string and numerical literals using `is` and `is not` operators causes python 3.8 to emit SyntaxWarning, such as the ones below. This PR aims to fix the comparisons. Relevant issue on python bug tracker is https://bugs.python.org/issue34850

```
/srv/web2py/applications/eden/modules/s3/s3resource.py:3928: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if id_column is 0:
/srv/web2py/applications/eden/modules/s3/s3gis.py:1350: SyntaxWarning: "is" with a literal. Did you mean "=="?
  elif config_id is 0:
/srv/web2py/applications/eden/modules/s3/s3import.py:1203: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  elif totals[1] is not 0:
/srv/web2py/applications/eden/modules/s3/s3import.py:1205: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  elif totals[2] is not 0:
```