### PR TITLE
Fix S3Translate Pootle export

### DIFF
--- a/optional_requirements.txt
+++ b/optional_requirements.txt
@@ -10,9 +10,9 @@ GDAL>=1.9.0 #from osgeo import ogr
 geopy>=1.18.1 #from geopy import geocoders
 # Warning: S3PDF unresolved dependency: reportlab required for PDF export
 reportlab>=2.5
-# Warning: S3Msg unresolved dependency pyserial required for Serial port modem usage
+# Warning: S3Msg unresolved dependency: pyserial required for Serial port modem usage
 pyserial>=2.6
-# Warning: S3Msg unresolved dependency tweepy required for non-Tropo Twitter support
+# Warning: S3Msg unresolved dependency: tweepy required for non-Tropo Twitter support
 tweepy>=1.9
 # Warning: S3XLS unresolved dependency: xlrd required for XLS export
 xlrd>=0.7.1
@@ -54,3 +54,5 @@ pyparsing>=2.0.1
 #pyshorteners>=0.6.1
 # Warning: S3Doc unresolved dependency: docx-mailmerge required to merge into docx templates (currently used by DRKCM)
 #docx-mailmerge>=0.4.0
+# Warning: S3Translate unresolved dependency: translate-toolkit required for Pootle support
+translate-toolkit>=1.0.1


### PR DESCRIPTION
This PR finishes the work done in #1468 also for Pootle files.

 - Fixes a variable forgotten during refactoring (line 810)
 - CSV files need to be always handled as text
 - _csv2po_ is imported and handled as python module instead of calling an external binary. This has several advantages
   - _csv2po_ binary is provided by _translate-toolkit_ python package. If we have the package, we don't need to run an extra process for it. Calling binaries is expensive.
   - subprocess.call() with shell=True (as required on Windows) requires the command to be a string, not list. This would require escaping for filename params (can be done via pipes.escape() on py<=2.6 and shlex.escape() on py>=2.7), but would uglify the code even further.
   - Errors in processing are obvious. E.g. when the _translate-toolkit_ was missing now, the error message complained about missing .po file and one needed to read the code to see that _csv2po_ has been called before and silently failed. Now the message would complain about missing module.
 - Temp file names for CSV and PO are generated from the same base name to ease debugging

Tested and works on
 - Python 2.7.17 @ GNU/Linux 4.15.0-66-generic x86_64 (Ubuntu 18.04, glibc)
 - Python 3.8.1 @ Linux 5.4.12-1-virt x86_64 (Alpine 3.11, musl libc)