### PR TITLE
Fix HTML+JS files translation export

### DIFF
--- a/controllers/admin.py
+++ b/controllers/admin.py
@@ -1192,10 +1192,12 @@ def translate():
             if form.accepts(request.vars, session):
                 # Retrieve strings from the uploaded file
                 from s3.s3translate import TranslateReadFiles
-                f = request.vars.upload.file
+                f = open(user_file, "rb")
+                user_data = request.vars.upload.file.read().decode("utf-8").splitlines()
+                f.close()
                 strings = []
                 R = TranslateReadFiles()
-                for line in f:
+                for line in user_data:
                     strings.append(line)
                 # Update the file containing user strings
                 R.merge_user_strings_file(strings)

--- a/modules/s3/s3translate.py
+++ b/modules/s3/s3translate.py
@@ -733,10 +733,10 @@ class TranslateReadFiles(object):
 
         html_js_file = open(filename, "rb")
         try:
-            html_js = html_js_file.read().decode("utf-8")
+            html_js = html_js_file.read().decode("utf-8").splitlines()
         except UnicodeDecodeError:
             try:
-                html_js = html_js_file.read().decode("latin-1")
+                html_js = html_js_file.read().decode("latin-1").splitlines()
             except UnicodeDecodeError:
                 current.log.warning("%s is not in either UTF-8 or LATIN-1 encoding" % filename)
                 return []
@@ -781,10 +781,9 @@ class TranslateReadFiles(object):
 
         if os.path.exists(user_file):
             f = open(user_file, "rb")
-            user_data = f.read().decode("utf-8")
+            user_data = f.read().decode("utf-8").splitlines()
             f.close()
             for line in user_data:
-                line = line.replace("\n", "").replace("\r", "")
                 strings.append((COMMENT, line))
 
         return strings
@@ -805,7 +804,7 @@ class TranslateReadFiles(object):
 
         if os.path.exists(user_file):
             f = open(user_file, "rb")
-            user_data = f.read().decode("utf-8")
+            user_data = f.read().decode("utf-8").splitlines()
             f.close()
             for line in user_data:
                 oappend(line)
@@ -815,6 +814,7 @@ class TranslateReadFiles(object):
         for s in newstrings:
             if s not in oldstrings:
                 f.write(s)
+                f.write('\n')
 
         f.close()
 


### PR DESCRIPTION
This PR fixes line iteration errors brought in in commits done in order to fix #1468.

Without the changes, the translations from HTML and JS files are not exported. The iteration logic remained from before the fix, when the for-loop has been run on the file object, which is not suitable now, when the file is fully read beforehand. Introducing `splitlines()` helps to solve that problem, along with line-ending sanitation, however it needed to be reflected in `merge_user_strings_file()`, hence the extra line-ending write (`\n` as recommended on https://docs.python.org/2/library/os.html?highlight=linesep#os.linesep )