### PR TITLE
setup: Don't crash when module doesn't have dependencies

### DIFF
--- a/modules/s3db/setup.py
+++ b/modules/s3db/setup.py
@@ -4601,28 +4601,29 @@ def setup_modules_apply(instance_id, modules):
                      "when": "not default.found",
                      })
             deps = dependencies.get(module)
-            for d in deps:
-                m = d.get("module")
-                if has_module(m):
-                    # No changes required
-                    # This is only the case for Local Server
-                    continue
-                tappend({"name": "Handle Dependency: If we disabled the module, then remove the disabling",
-                         "become": "yes",
-                         "lineinfile": {"dest": dest,
-                                        "regexp": '^del settings.modules\["%s"\]' % m,
-                                        "state": "absent",
-                                        },
-                         "register": "default",
-                         })
-                tappend({"name": "Handle Dependency: Enable the Module",
-                         "become": "yes",
-                         "lineinfile": {"dest": dest,
-                                        "regexp": '^settings.modules\["%s"\]' % module,
-                                        "line": 'settings.modules["%s"] = {"name_nice": T("%s"), "module_type": 10}' % (m, d.get("label")),
-                                        },
-                         "when": "not default.found",
-                         })
+            if deps is not None:
+                for d in deps:
+                    m = d.get("module")
+                    if has_module(m):
+                        # No changes required
+                        # This is only the case for Local Server
+                        continue
+                    tappend({"name": "Handle Dependency: If we disabled the module, then remove the disabling",
+                            "become": "yes",
+                            "lineinfile": {"dest": dest,
+                                            "regexp": '^del settings.modules\["%s"\]' % m,
+                                            "state": "absent",
+                                            },
+                            "register": "default",
+                            })
+                    tappend({"name": "Handle Dependency: Enable the Module",
+                            "become": "yes",
+                            "lineinfile": {"dest": dest,
+                                            "regexp": '^settings.modules\["%s"\]' % module,
+                                            "line": 'settings.modules["%s"] = {"name_nice": T("%s"), "module_type": 10}' % (m, d.get("label")),
+                                            },
+                            "when": "not default.found",
+                            })
         else:
             if not has_module(module):
                 # No changes required


### PR DESCRIPTION
This PR attempts to fix an error when a module without dependencies is enabled in *Setup* by adding a condition to check if there are any deps before trying to iterate over them.

Steps to reproduce on default template:
1. Go to *Setup*
2. Select *True* radiobutton for *Shelters*
3. Click on *Save*
```
Traceback (most recent call last):
  File "/srv/web2py/gluon/restricted.py", line 219, in restricted
    exec(ccode, environment)
  File "/srv/web2py/applications/eden/controllers/setup.py", line 776, in <module>
  File "/srv/web2py/gluon/globals.py", line 429, in <lambda>
    self._caller = lambda f: f()
  File "/srv/web2py/applications/eden/controllers/setup.py", line 545, in deployment
    return s3_rest_controller(rheader = s3db.setup_rheader,
  File "/srv/web2py/applications/eden/models/00_utils.py", line 245, in s3_rest_controller
    output = r(**attr)
  File "/srv/web2py/applications/eden/modules/s3/s3rest.py", line 688, in __call__
    output = handler(self, **attr)
  File "/srv/web2py/applications/eden/modules/s3db/setup.py", line 1935, in setup_instance_wizard
    result = setup_modules_apply(r.id, form.vars)
  File "/srv/web2py/applications/eden/modules/s3db/setup.py", line 4604, in setup_modules_apply
    for d in deps:
TypeError: 'NoneType' object is not iterable
```