### PR TITLE
req: Fix crash when person without skill is assigned

### DIFF
--- a/modules/s3db/req.py
+++ b/modules/s3db/req.py
@@ -4557,11 +4557,10 @@ def req_update_commit_quantities_and_status(req):
         rstable = s3db.req_req_skill
         query = (rstable.req_id == req_id) & \
                 (rstable.deleted == False)
-        status = set()
 
         if not any(row.quantity for row in cskills):
             # Nothing has been committed for this request so far
-            status.add(REQ_STATUS_NONE)
+            commit_status = REQ_STATUS_NONE
             db(query).update(quantity_commit=0)
         else:
             # Get all requested skill(set)s for this request


### PR DESCRIPTION
This PR fixes an exception when a person is committed to the request.

Steps to reproduce:
1. Go to *Organizations* -> *Facilities*
2. Create a facility filling in only the required fields (name)
3. Go to *Requests* -> *Requests* -> *Create*
4. Create a request for *People* filling in only the required fields (facility)
5. Go to *Requests* -> *Requests*
6. Click on *Commit* next to the previously created request and confirm the alert
7. Click on *Save Changes*
```
Traceback (most recent call last):
  File "/srv/web2py/gluon/restricted.py", line 219, in restricted
    exec(ccode, environment)
  File "/srv/web2py/applications/eden/controllers/req.py", line 1935, in <module>
  File "/srv/web2py/gluon/globals.py", line 429, in <lambda>
    self._caller = lambda f: f()
  File "/srv/web2py/applications/eden/controllers/req.py", line 1355, in commit
    return s3_rest_controller(rheader = commit_rheader)
  File "/srv/web2py/applications/eden/models/00_utils.py", line 245, in s3_rest_controller
    output = r(**attr)
  File "/srv/web2py/applications/eden/modules/s3/s3rest.py", line 691, in __call__
    output = self.resource.crud(self, **attr)
  File "/srv/web2py/applications/eden/modules/s3/s3rest.py", line 1775, in __call__
    output = self.apply_method(r, **attr)
  File "/srv/web2py/applications/eden/modules/s3/s3crud.py", line 106, in apply_method
    output = self.read(r, **attr)
  File "/srv/web2py/applications/eden/modules/s3/s3crud.py", line 637, in read
    return self.update(r, **attr)
  File "/srv/web2py/applications/eden/modules/s3/s3crud.py", line 947, in update
    form = self.sqlform(request=self.request,
  File "/srv/web2py/applications/eden/modules/s3/s3forms.py", line 1131, in __call__
    self.accept(form,
  File "/srv/web2py/applications/eden/modules/s3/s3forms.py", line 1257, in accept
    master_id, master_form_vars = self._accept(self.record_id,
  File "/srv/web2py/applications/eden/modules/s3/s3forms.py", line 1503, in _accept
    callback(onaccept, form, tablename=tablename)
  File "/srv/web2py/gluon/tools.py", line 81, in callback
    [action(form) for action in actions]
  File "/srv/web2py/gluon/tools.py", line 81, in <listcomp>
    [action(form) for action in actions]
  File "/srv/web2py/applications/eden/modules/s3db/req.py", line 3929, in commit_onaccept
    req_update_commit_quantities_and_status(req)
  File "/srv/web2py/applications/eden/modules/s3db/req.py", line 4633, in req_update_commit_quantities_and_status
    if commit_status != req.commit_status:
UnboundLocalError: local variable 'commit_status' referenced before assignment
```