### PR TITLE
Fix map marker image upload

### DIFF
--- a/modules/s3db/gis.py
+++ b/modules/s3db/gis.py
@@ -2349,7 +2349,7 @@ class S3GISConfigModel(S3Model):
 
         form_vars = form.vars
         image = form_vars.image
-        if image is None:
+        if not image:
             encoded_file = form_vars.get("imagecrop-data", None)
             if not encoded_file:
                 # No Image => CSV import of resources which just need a ref


### PR DESCRIPTION
This PR fixes map marker image upload which otherwise fails with
```
Traceback (most recent call last):
  File "/srv/web2py/gluon/restricted.py", line 219, in restricted
    exec(ccode, environment)
  File "/srv/web2py/applications/eden/controllers/gis.py", line 3937, in <module>
  File "/srv/web2py/gluon/globals.py", line 429, in <lambda>
    self._caller = lambda f: f()
  File "/srv/web2py/applications/eden/controllers/gis.py", line 1456, in marker
    return s3_rest_controller(rheader=s3db.gis_rheader)
  File "/srv/web2py/applications/eden/models/00_utils.py", line 245, in s3_rest_controller
    output = r(**attr)
  File "/srv/web2py/applications/eden/modules/s3/s3rest.py", line 691, in __call__
    output = self.resource.crud(self, **attr)
  File "/srv/web2py/applications/eden/modules/s3/s3rest.py", line 1775, in __call__
    output = self.apply_method(r, **attr)
  File "/srv/web2py/applications/eden/modules/s3/s3crud.py", line 104, in apply_method
    output = self.create(r, **attr)
  File "/srv/web2py/applications/eden/modules/s3/s3crud.py", line 387, in create
    output["form"] = self.sqlform(request = request,
  File "/srv/web2py/applications/eden/modules/s3/s3forms.py", line 467, in __call__
    success, error = self.process(form,
  File "/srv/web2py/applications/eden/modules/s3/s3forms.py", line 668, in process
    if form.accepts(vars,
  File "/srv/web2py/gluon/sqlhtml.py", line 1777, in accepts
    ret = FORM.accepts(
  File "/srv/web2py/gluon/html.py", line 2168, in accepts
    call_as_list(onvalidation, self)
  File "/srv/web2py/gluon/html.py", line 165, in call_as_list
    item(*a, **b)
  File "/srv/web2py/applications/eden/modules/s3db/gis.py", line 2370, in gis_marker_onvalidation
    extension = image.filename.rfind(".")
AttributeError: 'bytes' object has no attribute 'filename'
```
as the `image` property is not `None` but is an empty bytestring
```
<Storage {'name': 'aaa', 'imagecrop-points': '', 'image': b'', 'imagecrop-data': 'image.png;data:image/png;base64,...'}>
```