### PR TITLE
Minor fix

### DIFF
--- a/modules/s3/s3forms.py
+++ b/modules/s3/s3forms.py
@@ -1395,7 +1395,7 @@ class S3SQLCustomForm(S3SQLForm):
 
         # Retrieve the row
         return current.db(query).select(*fields,
-                                        limitby = (0, 1),
+                                        limitby = (0, 1)
                                         ).first()
 
     # -------------------------------------------------------------------------


### PR DESCRIPTION
Resolves a syntax error in modules/s3/s3forms.py which was causing failure on first run, with no relevant info why. I.e.

```
web2py Web Framework
Created by Massimo Di Pierro, Copyright 2007-2020
Version 2.18.5-stable+timestamp.2019.04.07.21.13.59
Database drivers available: sqlite3, imaplib, MySQLdb, pyodbc, pymysql

WARNING:  Setup unresolved dependency: boto required for Setup Module to be able to manage AWS EC2 keypairs
WARNING:  Setup unresolved dependency: ansible required for Setup Module
WARNING: Error when loading optional dependency: translate-toolkit
WARNING:  S3Msg unresolved dependency: pyserial required for Serial port modem usage
WARNING:  S3Doc unresolved dependency: sunburnt required for Full-Text Search support
WARNING:  Survey unresolved dependency: PyRTF required if you want to export assessment/survey templates as a Word document
WARNING:  Message Parsing unresolved dependency: TwitterSearch required for fetching results from twitter keyword queries
WARNING:  S3GIS unresolved dependency: GDAL required for Shapefile support
WARNING: Error when loading optional dependency: google-api-python-client
WARNING:  Setup unresolved dependency: openstacksdk required for Setup Module to be able to manage OpenStack instances
WARNING:  S3MSG unresolved dependency: sgmllib3k required for Feed import on Python 3.x
WARNING:  Setup unresolved dependency: dnspython required for Setup Module to be able to do DNS Lookups

ACTION REQUIRED: 
Traceback (most recent call last):
  File "web2py.py", line 33, in <module>
    gluon.widget.start(cron=True)
  File "/var/www/web2py/gluon/widget.py", line 1050, in start
    cronjob=options.cronjob)
  File "/var/www/web2py/gluon/shell.py", line 250, in run
    _env = env(a, c=c, f=f, import_models=import_models, extra_request=extra_request)
  File "/var/www/web2py/gluon/shell.py", line 172, in env
    run_models_in(environment)
  File "/var/www/web2py/gluon/compileapp.py", line 600, in run_models_in
    restricted(ccode, environment, layer=model)
  File "/var/www/web2py/gluon/restricted.py", line 219, in restricted
    exec(ccode, environment)
  File "applications/eden/models/000_1st_run.py", line 68, in <module>
    raise HTTP(500, body=html)
gluon.http.HTTP: 500 INTERNAL SERVER ERROR
```

This exception occurs because when the below import is attempted, the syntax error fixed by this PR causes as exception. I.e. this code ([`models/000_1st_run.py'](https://github.com/sahana/eden/blob/master/models/000_1st_run.py#L50-L53)):

```
    try:
        import s3 as s3base
    except Exception as e:
        errors.append(e.message)
```
`e.message` contains an empty string (so `errors` is a list which contains a single empty string). This is why the "ACTION REQUIRED:" is displayed, but with no info. FWIW `e.msg` = `invalid syntax (s3forms.py, line 1399)`.