### PR TITLE
Update Docker base image ubuntu to 18.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM ubuntu:14.10
+FROM ubuntu:18.04
+
+ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -y build-essential unzip curl python-pip python-dev python-matplotlib python-lxml \
 	python-numpy python-dateutil python-gdal python-yaml python-serial python-xlwt python-shapely python-pil python-gdal \


### PR DESCRIPTION
Ubuntu 14.10 was EOL-ed for years, currently the Ubuntu version being
used on Travis CI by eden is 18.04(bionic), should align the versions.

Also set DEBIAN_FRONTEND=noninteractive to prevent interactive apt-get
dialog from tzdata package after upgraded to Ubuntu 18.04.