### PR TITLE
Use COPY instead of ADD instruction in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN pip install selenium\>=2.23.0 sunburnt\>=0.6 TwitterSearch\>=1.0 requests\>=
 
 RUN curl -o web2py.zip https://codeload.github.com/web2py/web2py/zip/R-2.9.11 && unzip web2py.zip && mv web2py-R-2.9.11 /home/web2py && rm web2py.zip
 
-ADD . /home/web2py/applications/eden
+COPY . /home/web2py/applications/eden
 
 RUN cp /home/web2py/applications/eden/modules/templates/000_config.py /home/web2py/applications/eden/models/000_config.py && sed -i 's|EDITING_CONFIG_FILE = False|EDITING_CONFIG_FILE = True|' /home/web2py/applications/eden/models/000_config.py
 


### PR DESCRIPTION
Dockerfile best practices reference:

- https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#add-or-copy

> For other items (files, directories) that do not require `ADD`’s tar
> auto-extraction capability, you should always use `COPY`.