### PR TITLE
Enhance the number of features requested with wms getfeatureinfo

### DIFF
--- a/static/scripts/gis/gxp/plugins/WMSGetFeatureInfo.js
+++ b/static/scripts/gis/gxp/plugins/WMSGetFeatureInfo.js
@@ -155,6 +155,7 @@ gxp.plugins.WMSGetFeatureInfo = Ext.extend(gxp.plugins.Tool, {
                     layers: [layer],
                     infoFormat: infoFormat,
                     vendorParams: vendorParams,
+                    maxFeatures: 1000,
                     eventListeners: {
                         getfeatureinfo: function(evt) {
                             var title = x.get("title") || x.get("name");


### PR DESCRIPTION
This is e.g. needed when requesting clustered features. The default value of 10 is not enough. The minified version should be generated again with the closure compiler