### PR TITLE
Remove role delegations (and hence security policy 8), +bugfixes

### DIFF
--- a/modules/templates/BRCMS/config.py
+++ b/modules/templates/BRCMS/config.py
@@ -89,8 +89,6 @@ def config(settings):
     # 5: Apply Controller, Function & Table ACLs
     # 6: Apply Controller, Function, Table ACLs and Entity Realm
     # 7: Apply Controller, Function, Table ACLs and Entity Realm + Hierarchy
-    # 8: Apply Controller, Function, Table ACLs, Entity Realm + Hierarchy and Delegations
-    #
     settings.security.policy = 7 # Hierarchical Realms
 
     # Version details on About-page require login

--- a/modules/templates/CCC/config.py
+++ b/modules/templates/CCC/config.py
@@ -78,8 +78,6 @@ def config(settings):
     # 5: Apply Controller, Function & Table ACLs
     # 6: Apply Controller, Function, Table ACLs and Entity Realm
     # 7: Apply Controller, Function, Table ACLs and Entity Realm + Hierarchy
-    # 8: Apply Controller, Function, Table ACLs, Entity Realm + Hierarchy and Delegations
-
     settings.security.policy = 7 # Entity Realm + Hierarchy
 
     # Which page to go to after login?

--- a/modules/templates/CumbriaEAC/config.py
+++ b/modules/templates/CumbriaEAC/config.py
@@ -85,8 +85,6 @@ def config(settings):
     # 5: Apply Controller, Function & Table ACLs
     # 6: Apply Controller, Function, Table ACLs and Entity Realm
     # 7: Apply Controller, Function, Table ACLs and Entity Realm + Hierarchy
-    # 8: Apply Controller, Function, Table ACLs, Entity Realm + Hierarchy and Delegations
-
     settings.security.policy = 5 # Controller, Function & Table ACLs
 
     settings.ui.auth_user_represent = "name"

--- a/modules/templates/Data/config.py
+++ b/modules/templates/Data/config.py
@@ -117,8 +117,6 @@ def config(settings):
     # 5: Apply Controller, Function & Table ACLs
     # 6: Apply Controller, Function, Table ACLs and Entity Realm
     # 7: Apply Controller, Function, Table ACLs and Entity Realm + Hierarchy
-    # 8: Apply Controller, Function, Table ACLs, Entity Realm + Hierarchy and Delegations
-    #
     #settings.security.policy = 7 # Organisation-ACLs
 
     # This deployment exposes public data sets

--- a/modules/templates/Disease/config.py
+++ b/modules/templates/Disease/config.py
@@ -87,8 +87,6 @@ def config(settings):
     # 5: Apply Controller, Function & Table ACLs
     # 6: Apply Controller, Function, Table ACLs and Entity Realm
     # 7: Apply Controller, Function, Table ACLs and Entity Realm + Hierarchy
-    # 8: Apply Controller, Function, Table ACLs, Entity Realm + Hierarchy and Delegations
-
     settings.security.policy = 7 # Organisation-ACLs with Hierarchy
 
     def rgims_realm_entity(table, row):

--- a/modules/templates/IFRC/config.py
+++ b/modules/templates/IFRC/config.py
@@ -55,7 +55,7 @@ def config(settings):
     settings.base.session_db = True
 
     # Security Policy
-    settings.security.policy = 8 # Delegations
+    settings.security.policy = 7
     settings.security.map = True
 
     # Authorization Settings

--- a/modules/templates/RMS/config.py
+++ b/modules/templates/RMS/config.py
@@ -67,7 +67,7 @@ def config(settings):
     # System Settings
     # -------------------------------------------------------------------------
     # Security Policy
-    settings.security.policy = 8 # Delegations
+    settings.security.policy = 7
     settings.security.map = True
 
     # Authorization Settings
@@ -269,7 +269,7 @@ def config(settings):
         elif tablename in ("org_facility", "pr_forum", "pr_group"):
             # Facilities, Forums and Groups should be in the realm of the user's organisation
             use_user_organisation = True
-        
+
         elif tablename == "hrm_training":
             # Inherit realm entity from the related HR record
             htable = s3db.hrm_human_resource
@@ -3599,7 +3599,7 @@ Thank you"""
 
     # -------------------------------------------------------------------------
     def customise_inv_send_resource(r, tablename):
-    
+
         #from gluon import IS_IN_SET
 
         s3db = current.s3db
@@ -3886,7 +3886,7 @@ Thank you"""
                                     ),
                                 )
                 send_email = current.msg.send_by_pe_id
-                
+
                 T = current.T
                 session_s3 = current.session.s3
                 ui_language = session_s3.language
@@ -3894,7 +3894,7 @@ Thank you"""
                 subject_T = T("Stockpile Capacity in %(site)s Warehouse is less than %(threshold)s m3")
                 message_T = T("Stockpile Capacity in %(site)s Warehouse is less than %(threshold)s m3. Please review at: %(url)s")
                 alert_T = T("Stockpile Capacity in %(site)s Warehouse is less than %(threshold)s m3")
-                            
+
                 from .controllers import inv_operators_for_sites
                 operators = inv_operators_for_sites([site_id])[site_id]["operators"]
                 insert = ntable.insert
@@ -5610,7 +5610,7 @@ Thank you"""
             otable = s3db.org_organisation
             btable = s3db.org_organisation_branch
             ltable = db.org_organisation_organisation_type
-            
+
             rows = db(ltable.organisation_type_id == type_id).select(ltable.organisation_id)
             all_rc_organisation_ids = [row.organisation_id for row in rows]
             query = (btable.deleted != True) & \
@@ -5626,7 +5626,7 @@ Thank you"""
             child_pe_ids = pr_get_descendants(pe_ids, entity_types=entity_types)
 
             entities = pe_ids + child_pe_ids
-            
+
         else:
             # Filter to entities the user has the ORG_ADMIN or logs_manager role for
 

--- a/modules/templates/SAFIRE/config.py
+++ b/modules/templates/SAFIRE/config.py
@@ -65,8 +65,6 @@ def config(settings):
     # 5: Apply Controller, Function & Table ACLs
     # 6: Apply Controller, Function, Table ACLs and Entity Realm
     # 7: Apply Controller, Function, Table ACLs and Entity Realm + Hierarchy
-    # 8: Apply Controller, Function, Table ACLs, Entity Realm + Hierarchy and Delegations
-
     settings.security.policy = 5 # Controller, Function & Table ACLs
 
     # -------------------------------------------------------------------------
@@ -565,7 +563,7 @@ def config(settings):
                 result = standard_prep(r)
                 if not result:
                     return False
-        
+
             if r.method == "create":
                 incident_id = r.get_vars.get("incident_id")
                 if incident_id:

--- a/modules/templates/SAMBRO/config.py
+++ b/modules/templates/SAMBRO/config.py
@@ -56,7 +56,6 @@ def config(settings):
     # 5: Apply Controller, Function & Table ACLs
     # 6: Apply Controller, Function, Table ACLs and Entity Realm
     # 7: Apply Controller, Function, Table ACLs and Entity Realm + Hierarchy
-    # 8: Apply Controller, Function, Table ACLs, Entity Realm + Hierarchy and Delegations
     settings.security.policy = 4 # Controller-Function ACLs
 
     # Record Approval

--- a/modules/templates/SHARE/config.py
+++ b/modules/templates/SHARE/config.py
@@ -97,8 +97,6 @@ def config(settings):
     # 5: Apply Controller, Function & Table ACLs
     # 6: Apply Controller, Function, Table ACLs and Entity Realm
     # 7: Apply Controller, Function, Table ACLs and Entity Realm + Hierarchy
-    # 8: Apply Controller, Function, Table ACLs, Entity Realm + Hierarchy and Delegations
-
     settings.security.policy = 6 # Controller, Function, Table ACLs and Entity Realm
 
     # Don't show version info on About page

--- a/modules/templates/UCCE/config.py
+++ b/modules/templates/UCCE/config.py
@@ -58,8 +58,6 @@ def config(settings):
     # 5: Apply Controller, Function & Table ACLs
     # 6: Apply Controller, Function, Table ACLs and Entity Realm
     # 7: Apply Controller, Function, Table ACLs and Entity Realm + Hierarchy
-    # 8: Apply Controller, Function, Table ACLs, Entity Realm + Hierarchy and Delegations
-
     settings.security.policy = 6 # Controller, Function, Table ACLs and Entity Realm
 
     # L10n settings
@@ -283,7 +281,7 @@ def config(settings):
                 query = (ttable.template_id == row.id) & \
                         (ltable.target_id == ttable.id) & \
                         (ltable.project_id == ptable.id)
-                
+
             project = current.db(query).select(ptable.realm_entity,
                                                limitby = (0, 1)
                                                ).first()
@@ -1201,7 +1199,7 @@ def config(settings):
                                                                     ).first()
                 if l10n:
                     s3db.dc_target_l10n.language.default = l10n.language
-            
+
             elif r.method == "datalist":
                 # Over-ride list_fields set in default prep
                 s3db.configure("project_project",

--- a/modules/templates/default/Demo/config.py
+++ b/modules/templates/default/Demo/config.py
@@ -95,8 +95,6 @@ def config(settings):
     # 5: Apply Controller, Function & Table ACLs
     # 6: Apply Controller, Function, Table ACLs and Entity Realm
     # 7: Apply Controller, Function, Table ACLs and Entity Realm + Hierarchy
-    # 8: Apply Controller, Function, Table ACLs, Entity Realm + Hierarchy and Delegations
-    #
     settings.security.policy = 1 # Simple Policy
 
     # Events

--- a/modules/templates/default/config.py
+++ b/modules/templates/default/config.py
@@ -485,8 +485,6 @@ def config(settings):
     # 5: Apply Controller, Function & Table ACLs
     # 6: Apply Controller, Function, Table ACLs and Entity Realm
     # 7: Apply Controller, Function, Table ACLs and Entity Realm + Hierarchy
-    # 8: Apply Controller, Function, Table ACLs, Entity Realm + Hierarchy and Delegations
-
     settings.security.policy = 5 # Controller, Function & Table ACLs
 
     # Ownership-rule for records without owner:

--- a/modules/templates/skeleton/config.py
+++ b/modules/templates/skeleton/config.py
@@ -129,8 +129,6 @@ def config(settings):
     # 5: Apply Controller, Function & Table ACLs
     # 6: Apply Controller, Function, Table ACLs and Entity Realm
     # 7: Apply Controller, Function, Table ACLs and Entity Realm + Hierarchy
-    # 8: Apply Controller, Function, Table ACLs, Entity Realm + Hierarchy and Delegations
-    #
     #settings.security.policy = 7 # Organisation-ACLs
 
     # -------------------------------------------------------------------------


### PR DESCRIPTION
As discussed, dropping role delegations (and thereby security policy 8):
- there is no current use-case (and never has been), and no user interface to manage delegations
- the mechanism of role delegations is difficult for users to understand
- keeping it means a considerable security risk due to complexity
- removing it makes auth code easier to understand and maintain, lower risk for bugs