### PR TITLE
Inv: Avoid NoneType error with default settings.ui.export_formats

### DIFF
--- a/modules/s3db/inv.py
+++ b/modules/s3db/inv.py
@@ -9290,7 +9290,7 @@ def inv_recv_controller():
         if record:
             status = record.status
 
-        export_formats = settings.ui.export_formats
+        export_formats = settings.get_ui_export_formats()
         if "pdf" in export_formats:
             # Use 'form' instead of standard PDF exporter
             export_formats = list(export_formats)
@@ -14606,7 +14606,7 @@ def inv_send_controller():
     def prep(r):
         send_req = settings.get_inv_send_req()
 
-        export_formats = settings.ui.export_formats
+        export_formats = settings.get_ui_export_formats()
         if "pdf" in export_formats:
             # Use 'form' instead of standard PDF exporter
             export_formats = list(export_formats)


### PR DESCRIPTION
Navigating to `/eden/inv/send` and `eden/inv/recv` with `settings.ui.export_formats` left commented in `config.py` currently fails with the following error

```pytb
Traceback (most recent call last):
  File "/srv/web2py/gluon/restricted.py", line 219, in restricted
    exec(ccode, environment)
  File "/srv/web2py/applications/eden/controllers/inv.py", line 1469, in <module>
  File "/srv/web2py/gluon/globals.py", line 430, in <lambda>
    self._caller = lambda f: f()
  File "/srv/web2py/applications/eden/controllers/inv.py", line 435, in recv
    return inv_recv_controller()
  File "/srv/web2py/applications/eden/modules/s3db/inv.py", line 9894, in inv_recv_controller
    return current.rest_controller("inv", "recv",
  File "/srv/web2py/applications/eden/models/00_utils.py", line 268, in s3_rest_controller
    output = r(**attr)
  File "/srv/web2py/applications/eden/modules/s3/s3rest.py", line 662, in __call__
    pre = preprocess(self)
  File "/srv/web2py/applications/eden/modules/s3db/inv.py", line 9294, in prep
    if "pdf" in export_formats:
TypeError: argument of type 'NoneType' is not iterable
```

This PR updates the `inv` code to call the function to get the proper configuration value even if the value is not configured explicitly.