### PR TITLE
A branch will never be taken.

### DIFF
--- a/modules/nameparser/parser.py
+++ b/modules/nameparser/parser.py
@@ -564,6 +564,9 @@ class HumanName(object):
                 except IndexError:
                     pass
 
+        # Warning: Collection length comparison should be meaningful.
+        # The length of a collection is always greater than or equal to zero.
+        # So testing that a length is less than zero is always false.
         if len(self) < 0:
             log.info("Unparsable: \"{}\" ".format(self.original))
         else:


### PR DESCRIPTION
In file: parser.py, the comparison of Collection length creates a logical short circuit. The path in the code will never be taken. I am not suggesting a fix, just raising attention to the inconsistency here.